### PR TITLE
Update CodeIgniter.php to check Bonfire Controllers

### DIFF
--- a/bonfire/ci3/core/CodeIgniter.php
+++ b/bonfire/ci3/core/CodeIgniter.php
@@ -402,13 +402,19 @@ if ( ! is_php('5.4'))
 	$class = ucfirst($RTR->class);
 	$method = $RTR->method;
 
-	if (empty($class) OR ! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php'))
+	if (empty($class) 
+	    OR (! file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php')
+            AND ! file_exists(BFPATH.'controllers/'.$RTR->directory.$class.'.php')))
 	{
 		$e404 = TRUE;
 	}
 	else
 	{
-		require_once(APPPATH.'controllers/'.$RTR->directory.$class.'.php');
+		if(file_exists(APPPATH.'controllers/'.$RTR->directory.$class.'.php')) {
+            		require_once(APPPATH . 'controllers/' . $RTR->directory . $class . '.php');
+        	} elseif(file_exists(BFPATH.'controllers/'.$RTR->directory.$class.'.php')) {
+            		require_once(BFPATH . 'controllers/' . $RTR->directory . $class . '.php');
+        	}
 
 		if ( ! class_exists($class, FALSE) OR $method[0] === '_' OR method_exists('CI_Controller', $method))
 		{


### PR DESCRIPTION
As per https://github.com/ci-bonfire/Bonfire/issues/1260 CI wasn't looking in the bonfire folder for the install.php. The code above checks both APPPATH and BFPATH. Since there is only the install.php and Images.php it might be easier just moving those controllers into application?